### PR TITLE
refactor: use glob for locating documents

### DIFF
--- a/lib/get-all-markdown-docs.js
+++ b/lib/get-all-markdown-docs.js
@@ -1,37 +1,21 @@
 'use strict';
 
-const _ = require('lodash');
 const debug = require('../lib/debug')('get-all-markdown-docs');
 const promisify = require('util').promisify;
+const glob = promisify(require('glob'));
+const path = require('path');
 const fs = require('fs');
 const readFileAsync = promisify(fs.readFile);
-const statAsync = promisify(fs.stat);
-
-const readdirAsync = promisify(require('readdir-absolute'));
 
 module.exports = async function getAllMarkdownDocs(docPath) {
-  let docQueue = [docPath];
-  let markdownDocs = {};
-  while (docQueue.length > 0) {
-    const dir = docQueue.shift();
-    debug(`next target: ${dir}`);
-    if (_.endsWith(dir, '.md')) {
-      // We used the absolute path for recursive parsing, but we need to
-      // ditch it now.
-      let doc = await readFileAsync(dir, 'utf-8');
-      let relPath = dir.substring(docPath.length, dir.length);
-      debug(`Adding to docs: "${relPath}"`);
-      markdownDocs[relPath] = doc;
-    } else {
-      const dirStat = await statAsync(dir);
-      if (dirStat.isDirectory()) {
-        // Queue 'em up!
-        _.each(await readdirAsync(dir), x => {
-          docQueue.push(x);
-        });
-      }
-      // Otherwise, ignore it and move on.
-    }
+  debug(`retrieving docs from ${docPath}`);
+  let contents = {};
+  const docs = await glob(path.join(docPath, '**/*.md'),
+    { matchBase: true });
+  for (const doc of docs) {
+    let content = await readFileAsync(doc, 'utf-8');
+    let relPath = doc.substring(docPath.length, doc.length);
+    contents[relPath] = content;
   }
-  return markdownDocs;
+  return contents;
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "debug": "^3.1.0",
     "eslint": "^4.18.1",
     "fs-extra": "^5.0.0",
+    "glob": "^7.1.2",
     "lodash": "^4.17.5",
     "readdir-absolute": "^1.0.1",
     "simple-git": "^1.91.0",

--- a/test/get-all-markdown-docs.test.js
+++ b/test/get-all-markdown-docs.test.js
@@ -10,8 +10,11 @@ tap.test('get-all-markdown-docs', async t => {
   );
   t.ok(results, 'results were returned');
   t.ok(Object.keys(results).length > 0, 'document collection was not empty');
-  t.ok(results['/flavours/chocolate.md'], 'chocolate was included');
-  t.ok(results['/flavours/vanilla.md'], 'vanilla was included');
-  t.ok(results['/ice-cream.md'], 'ice-cream was included');
+  t.contains(results['/flavours/chocolate.md'], 'Mmm, chocolate',
+    'chocolate was included');
+  t.contains(results['/flavours/vanilla.md'], 'it\'s also got vanilla in it!',
+    'vanilla was included');
+  t.contains(results['/ice-cream.md'], 'the only 2 flavours of ice cream',
+    'ice-cream was included');
   t.end();
 });


### PR DESCRIPTION
- Use glob
- Make tests stronger (assert against doc contents)